### PR TITLE
HACS Update

### DIFF
--- a/custom_components/eero_tracker/manifest.json
+++ b/custom_components/eero_tracker/manifest.json
@@ -4,5 +4,6 @@
   "documentation": "https://github.com/jrlucier/eero_tracker",
   "dependencies": [],
   "codeowners": ["@jrlucier"],
-  "requirements": ["requests>=2.13.0"]
+  "requirements": ["requests>=2.13.0"],
+  "homeassistant": "0.92.0"
 }


### PR DESCRIPTION
Hi there!

I recently installed HACS (https://github.com/custom-components/hacs) and it allows you to add custom components not yet in it's registry via a github link.

However, when I went to add your project it kept giving me an error. In reading the forums, this is because you are using "releases" on github, but it couldn't find a "homeassistant" value when scanning the manifest.json file.

See the last post here:

https://community.home-assistant.io/t/hacs-question-about-adding-repositories/121517/26

And the description of the JSON name/value pair here.

https://custom-components.github.io/hacs/developer/integration/#github-releases-optional

So I added the homeassistant version of "92" to the manifest file, and then tested my repository against HACS - and boom! It works and allows me to install. So I thought I'd submit this pull request. It's a very minor change, but I thought I'd save you the work! Love this component, so HTH!