### PR TITLE
Add config flow to onboard eero tracker integration

### DIFF
--- a/custom_components/eero_tracker/__init__.py
+++ b/custom_components/eero_tracker/__init__.py
@@ -1,0 +1,6 @@
+from .const import (
+    DOMAIN
+)
+
+def setup(hass, config):
+    return True

--- a/custom_components/eero_tracker/config_flow.py
+++ b/custom_components/eero_tracker/config_flow.py
@@ -1,0 +1,55 @@
+import logging
+import voluptuous as vol
+
+from collections import OrderedDict
+from homeassistant import config_entries
+
+from .const import (
+    DOMAIN,
+    EERO_SESSION_COOKIE_FILE,
+)
+
+from .eero import (
+    CookieStore,
+    Eero,
+)
+
+_LOGGER = logging.getLogger(__name__)
+
+@config_entries.HANDLERS.register(DOMAIN)
+class EeroFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
+
+    def __init__(self):
+        self.session = CookieStore(EERO_SESSION_COOKIE_FILE)
+        self.eero = Eero(self.session)
+        self.token = None
+        self.username = None
+
+        self.user_step_schema = vol.Schema({ vol.Required("username"): str })
+        self.verify_step_schema = vol.Schema({ vol.Required("verification_code"): str })
+
+    async def async_step_user(self, user_input=None):
+        _LOGGER.debug("Handle user step with input", user_input)
+        if user_input is not None:
+            self.username = user_input["username"]
+            _LOGGER.debug("Starting login for user", self.username)
+            await self.async_set_unique_id(self.username)
+            self.token = self.eero.login(self.username)
+            _LOGGER.debug("Retrieved token", self.token)
+            return self.async_show_form(
+                step_id="verify", data_schema=self.verify_step_schema
+            )
+
+        _LOGGER.debug("Starting login flow")
+        return self.async_show_form(
+            step_id="user", data_schema=self.user_step_schema
+        )
+
+    async def async_step_verify(self, user_input=None):
+        _LOGGER.debug("Verifiying user")
+        self.eero.login_verify(user_input["verification_code"], self.token)
+        _LOGGER.debug("Verification successful")
+        return self.async_create_entry(
+            title=f"Eero - {self.username}",
+            data={"username": self.username}
+        )

--- a/custom_components/eero_tracker/const.py
+++ b/custom_components/eero_tracker/const.py
@@ -1,0 +1,2 @@
+DOMAIN = "eero_tracker"
+EERO_SESSION_COOKIE_FILE = "eero.session"

--- a/custom_components/eero_tracker/eero.py
+++ b/custom_components/eero_tracker/eero.py
@@ -1,0 +1,123 @@
+import re
+import json
+import requests
+from argparse import ArgumentParser
+from abc import abstractproperty
+
+
+class Eero(object):
+    def __init__(self, arg_session):
+        # type(SessionStorage) -> ()
+        self.session = arg_session
+        self.client = Client()
+
+    @property
+    def _cookie_dict(self):
+        if self.needs_login():
+            return dict()
+        else:
+            return dict(s=self.session.cookie)
+
+    def needs_login(self):
+        return self.session.cookie is None
+
+    def login(self, identifier):
+        # type(string) -> string
+        json = dict(login=identifier)
+        data = self.client.post('login', json=json)
+        return data['user_token']
+
+    def login_verify(self, verification_code, user_token):
+        json = dict(code=verification_code)
+        response = self.client.post('login/verify', json=json,
+                                    cookies=dict(s=user_token))
+        self.session.cookie = user_token
+        return response
+
+    def refreshed(self, func):
+        try:
+            return func()
+        except ClientException as exception:
+            if exception.status == 401 and exception.error_message == 'error.session.refresh':
+                self.login_refresh()
+                return func()
+            else:
+                raise
+
+    def login_refresh(self):
+        response = self.client.post('login/refresh', cookies=self._cookie_dict)
+        self.session.cookie = response['user_token']
+
+    def account(self):
+        return self.refreshed(lambda: self.client.get(
+            'account',
+            cookies=self._cookie_dict))
+
+    @staticmethod
+    def id_from_url(id_or_url):
+        match = re.search('^[0-9]+$', id_or_url)
+        if match:
+            return match.group(0)
+        match = re.search(r'\/([0-9]+)$', id_or_url)
+        if match:
+            return match.group(1)
+
+    def devices(self, network_id):
+        return self.refreshed(lambda: self.client.get(
+            'networks/{}/devices'.format(
+                self.id_from_url(network_id)), cookies=self._cookie_dict))
+
+
+class SessionStorage(object):
+    @abstractproperty
+    def cookie(self):
+        pass
+
+
+class ClientException(Exception):
+    def __init__(self, status, error_message):
+        super(ClientException, self).__init__()
+        self.status = status
+        self.error_message = error_message
+
+
+class Client(object):
+    API_ENDPOINT = 'https://api-user.e2ro.com/2.2/{}'
+
+    @staticmethod
+    def _parse_response(response):
+        data = json.loads(response.text)
+        if data['meta']['code'] != 200 and data['meta']['code'] != 201:
+            raise ClientException(data['meta']['code'],
+                                  data['meta'].get('error', ""))
+        return data.get('data', "")
+
+    def post(self, action, **kwargs):
+        response = requests.post(self.API_ENDPOINT.format(action), **kwargs)
+        return self._parse_response(response)
+
+    def get(self, action, **kwargs):
+        response = requests.get(self.API_ENDPOINT.format(action), **kwargs)
+        return self._parse_response(response)
+
+
+class CookieStore(SessionStorage):
+    def __init__(self, cookie_file):
+        from os import path
+        self.cookie_file = path.abspath(cookie_file)
+
+        try:
+            with open(self.cookie_file, 'r') as f:
+                self.__cookie = f.read()
+        except IOError:
+            self.__cookie = None
+
+    @property
+    def cookie(self):
+        return self.__cookie
+
+    @cookie.setter
+    def cookie(self, cookie):
+        self.__cookie = cookie
+        with open(self.cookie_file, 'w+') as f:
+            f.write(self.__cookie)

--- a/custom_components/eero_tracker/manifest.json
+++ b/custom_components/eero_tracker/manifest.json
@@ -1,6 +1,7 @@
 {
   "domain": "eero_tracker",
   "name": "Eero Tracker",
+  "config_flow": true,
   "documentation": "https://github.com/jrlucier/eero_tracker/",
   "dependencies": [],
   "codeowners": ["@jrlucier"],

--- a/custom_components/eero_tracker/strings.json
+++ b/custom_components/eero_tracker/strings.json
@@ -1,0 +1,19 @@
+{
+    "config": {
+        "title": "Eero",
+        "step": {
+            "user": {
+                "title": "Sign-in with Eero account",
+                "data": {
+                    "username": "Email or Phone Number for your Eero account"
+                }
+            },
+            "verify": {
+                "title": "Verify",
+                "data": {
+                    "verification_code": "Enter the verification code that was sent to your email or phone number"
+                }
+            }
+        }
+    }
+}

--- a/custom_components/eero_tracker/translations/en.json
+++ b/custom_components/eero_tracker/translations/en.json
@@ -1,0 +1,19 @@
+{
+    "config": {
+        "title": "Eero",
+        "step": {
+            "user": {
+                "title": "Sign-in with Eero account",
+                "data": {
+                    "username": "Email or Phone Number for your Eero account"
+                }
+            },
+            "verify": {
+                "title": "Verify",
+                "data": {
+                    "verification_code": "Enter the verification code that was sent to your email or phone number"
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Hey!

Hopefully this is useful :)

This PR adds a very basic config flow to set up the Eero integration - accepting an email or phone number, then a verification code, and writing the `eero.session` file. This allows users to create the session file via the UI rather than running a python script :)

Note that I copied most of the relevant parts from the `eero_tracker_instantiate.py` file into `eero.py` within the custom component, so that the eero client can be used in the config flow and other parts of the custom component. It should be possible to refactor away some of the duplication between this and `device_tracker.py` but I don't want this PR to have too big a blast-radius!

Cheers,
Jack